### PR TITLE
Update docs.md

### DIFF
--- a/06.api-reference/04.audio/docs.md
+++ b/06.api-reference/04.audio/docs.md
@@ -34,7 +34,7 @@ taxonomy:
 
 ## Audio.playSound() <a id="method-1"></a>
 
-`Audio.playSound()` triggers playback of an audio file by sending it to the audio mixer. To use this API to play (aka "inject") a sound, the sound file must have been previously loaded using [SoundCache.getSound()](https://wiki.highfidelity.com/wiki/SoundCache.getSound()).
+`Audio.playSound()` triggers playback of an audio file by sending it to the audio mixer. To use this API to play (aka "inject") a sound, the sound file must have been previously loaded using [SoundCache.getSound()](https://wiki.highfidelity.com/wiki/SoundCache.getSound\(\)).
 
 If the client is not connected to an audio mixer, no sound will be played unless the localOnly option is invoked (see below.)
 
@@ -44,7 +44,7 @@ If the client is not connected to an audio mixer, no sound will be played unless
 
 ### Arguments
 
-**Sound\*** The sound object returned from [SoundCache.getSound()](https://wiki.highfidelity.com/wiki/SoundCache.getSound()).
+**Sound\*** The sound object returned from [SoundCache.getSound()](https://wiki.highfidelity.com/wiki/SoundCache.getSound\(\)).
 
 Below are options you can pass to `Audio.playSound()`:
 


### PR DESCRIPTION
Throughout the api guide there are issues with linking related to methods calls.  I believe this is due to the markdown link syntax of []() being disturbed by the use of the () after the method name, i.e. 'SoundCache.getSound()'.  I think this can be fixed with escaping the method's argument parenthesis.  Hard to tell if it fixes it from editing on github as it already accounts for that issue, but I will fix the other ones I see just in case as I'm pretty certain that is the issue but could always be wrong.