### PR TITLE
run 6 assignment-clients instead of 5

### DIFF
--- a/04.build-guide/07.command-line-guide/docs.md
+++ b/04.build-guide/07.command-line-guide/docs.md
@@ -69,7 +69,7 @@ cd ~/my-repo/build/domain-server/
 ```
 cd ~/my-repo/build/assignment-client/
 mkdir resources
-./assignment-client -n 5
+./assignment-client -n 6
 
 ```
 


### PR DESCRIPTION
Since these docs were created there was another assignment-client type added to the typical hifi domain stack, so you want to start with 6 AC's rather than just 5.  I'm not sure what role the new AC plays but @birarda might know; I think it has something to do with assets.