### PR TITLE
Fix some typo mistakes in 3d modeling documentation.

### DIFF
--- a/02.create-and-explore/07.3d-modeling/01.materials-export-guide/docs.md
+++ b/02.create-and-explore/07.3d-modeling/01.materials-export-guide/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-he High Fidelity Material defines several channels of data used by the rendering engine. These channels can be configured in different ways from different fields as indicated by the following table:
+The High Fidelity Material defines several channels of data used by the rendering engine. These channels can be configured in different ways from different fields as indicated by the following table:
 
 | Channel   | Fields      | Type            | Configurations | Results           |
 | --------- | ----------- | --------------- | -------------- | ----------------- |

--- a/02.create-and-explore/07.3d-modeling/03.best-practices/docs.md
+++ b/02.create-and-explore/07.3d-modeling/03.best-practices/docs.md
@@ -4,7 +4,7 @@ taxonomy:
     category: docs
 ---
 
-**Learn the best practices for making 3D content in VR.*
+*Learn the best practices for making 3D content in VR.*
 
 ## Overview
 

--- a/02.create-and-explore/07.3d-modeling/docs.md
+++ b/02.create-and-explore/07.3d-modeling/docs.md
@@ -32,7 +32,7 @@ There are many great tutorials and videos for the various 3D packages online inc
 
 If you are using Blender to create an avatar, check out the [Blender workflow](https://wiki.highfidelity.com/wiki/Blender_workflow) tutorial.
 
-Another great tool is the [Autodesk FBX converter](http://usa.autodesk.com/adsk/servlet/pc/item?siteID=123112&id=22694909):
+Another great tool is the [Autodesk FBX converter](http://usa.autodesk.com/adsk/servlet/pc/item?siteID=123112&id=22694909).
 
 For more detailed information on exporting materials from Maya or Blender to High Fidelity, see the [Material Export Guide](https://wiki.highfidelity.com/wiki/Material_Export_Guide).
 


### PR DESCRIPTION
Fixed "The" word, removed an asterisk and ":" because there is not anythig after it.