### PR TITLE
WIP: Fixing subsurface scattering

### DIFF
--- a/02.create-and-explore/09.extras/02.subsurface-scattering/docs.md
+++ b/02.create-and-explore/09.extras/02.subsurface-scattering/docs.md
@@ -33,11 +33,11 @@ To create the SSS effect on an avatar, do the following:
 2. Create a scattering map for the subsurface scattering in Photoshop or equivalent.
 3. Use [Interface](https://wiki.highfidelity.com/wiki/Interface) to package the avatar and generate the FST.
 4. Add a description of the SSS to the FST using the JSON syntax.
-5. Link to your avatar's FST in Interface
+5. Link to your avatar's FST in Interface.
 
 ## Scattering Effect Examples
 
-Here's an example of the scattering effect. The left image has no scattering and the right image has scattering. You can see the red diffuse reflection along the shadow line and
+Here's an example of the scattering effect. The left image has no scattering and the right image has scattering. You can see the red diffuse reflection along the shadow line.
 
 | ![](no-scattering.jpg) | ![](scattering.jpg) |
 | ---------------------- | ------------------- |
@@ -64,7 +64,7 @@ Here are examples of two FSTs that contain scattering definitions.
 
   \- A developers debug script which allows you to toggle the material properties in realtime:
 
-   
+
 
   http://rawgit.com/highfidelity/hifi/3d57a3a86a94bda5498bb315c700006584d725fc/scripts/developer/utilities/render/debugDeferredLighting.js
 


### PR DESCRIPTION
This comment is about https://docs.highfidelity.com/create-and-explore/extras/subsurface-scattering .

In line 48 (second table) there is an empty link to a image that does not exists but I cannot create it. Do you have the image in some place of your hard disk?

In line 71 there is a broken link to a image in wiki.highfidelity.com (DebugDeferredLighting.jpg) but I cannot find the image. Could be possible to access highfidelity wiki to download lost images and fix broken links: https://forums.highfidelity.com/t/broken-documentation/12964

