### PR TITLE
Adding line for clarity in getEntityProperties

### DIFF
--- a/06.api-reference/15.entities/docs.md
+++ b/06.api-reference/15.entities/docs.md
@@ -1936,6 +1936,7 @@ var Ent = Entities.addEntity(properties);
 
 // create a second entity that is a copy of the first by passing in the first entity's properties 
 var copyEnt = Entities.addEntity(Entities.getEntityProperties(Ent));
+print(JSON.stringify(Entities.getEntityProperties(Ent).type));
 
 ```
 


### PR DESCRIPTION
Adding a debug line to show a way to retrieve a property. This is in another example, but it should be under the method reference as well.