### PR TITLE
Keybindings for scaling the avatar

### DIFF
--- a/02.create-and-explore/02.explore-interface/01.basic-controls/docs.md
+++ b/02.create-and-explore/02.explore-interface/01.basic-controls/docs.md
@@ -104,8 +104,9 @@ Here are some other useful shortcuts for High Fidelity:
 
 | Avatar Manipulation | Key |
 | ------------- | ------------- |
-| Decrease Avatar Size | <kbd class="keyboard">CTRL</kbd> + <kbd class="keyboard">-</kbd>  |
-| Increase Avatar Size  | <kbd class="keyboard">CTRL</kbd> + <kbd class="keyboard">+</kbd>  |
+| Decrease Avatar Size | <kbd class="keyboard">-</kbd>  |
+| Increase Avatar Size  | <kbd class="keyboard">+</kbd>  |
+| Reset Avatar Size  | <kbd class="keyboard">=</kbd>  |
 
 <br>
 


### PR DESCRIPTION
`CTRL` + `+`   >   `+`    
`CTRL` + `-`   >   `-`    

and added the missing reset key `=`

Tested in RC67.1 (build 8265)